### PR TITLE
The PUT views should return an empty bytes string.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,16 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - nightly
+  - 3.6
 sudo: false
 install:
-    - pip install tox-travis
+    - pip install -U pip setuptools
+    - pip install -U zope.testrunner
+    - pip install -U -e .[test]
 script:
-    - tox
+    - zope-testrunner --test-path=src
 notifications:
     email: false
+cache: pip
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,10 +2,12 @@
 CHANGES
 =======
 
-4.1.0 (unreleased)
+4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The PUT views return an empty byte string instead of an empty native
+  string. On Python 3, the unicode native string leads to a TypeError
+  in zope.publisher.http.
 
 
 4.0.0 (2016-08-08)

--- a/src/zope/app/http/put.py
+++ b/src/zope/app/http/put.py
@@ -88,7 +88,7 @@ class NullPUT(object):
         request.response.setStatus(201)
         request.response.setHeader(
             'Location', zope.traversing.browser.absoluteURL(newfile, request))
-        return ''
+        return b''
 
 
 class FilePUT(object):
@@ -111,4 +111,4 @@ class FilePUT(object):
         length = int(self.request.get('CONTENT_LENGTH', -1))
         adapter.write(body.read(length))
 
-        return ''
+        return b''

--- a/src/zope/app/http/tests/test_put.py
+++ b/src/zope/app/http/tests/test_put.py
@@ -76,7 +76,7 @@ class TestNullPUT(TestCase):
         null = zope.app.http.put.NullResource(container, 'spam.txt')
         put = zope.app.http.put.NullPUT(null, request)
         self.assertEqual(getattr(container, 'spam', None), None)
-        self.assertEqual(put.PUT(), '')
+        self.assertEqual(put.PUT(), b'')
         request.response.setResult('')
         file = getattr(container, 'spam.txt')
         self.assertEqual(file.__class__, File)
@@ -106,7 +106,7 @@ class TestNullPUT(TestCase):
         null = zope.app.http.put.NullResource(container, 'spam')
         put = zope.app.http.put.NullPUT(null, request)
         self.assertEqual(getattr(container, 'spam', None), None)
-        self.assertEqual(put.PUT(), '')
+        self.assertEqual(put.PUT(), b'')
         request.response.setResult('')
 
         # Check HTTP Response
@@ -136,7 +136,7 @@ class TestFilePUT(TestCase):
                                'CONTENT_LENGTH': str(len(content)),
                                })
         put = zope.app.http.put.FilePUT(file, request)
-        self.assertEqual(put.PUT(), '')
+        self.assertEqual(put.PUT(), b'')
         request.response.setResult('')
         self.assertEqual(file.data, content)
 
@@ -153,7 +153,7 @@ class TestFilePUT(TestCase):
                                'HTTP_CONTENT_FOO': 'Bar',
                                })
         put = zope.app.http.put.FilePUT(file, request)
-        self.assertEqual(put.PUT(), '')
+        self.assertEqual(put.PUT(), b'')
         request.response.setResult('')
         self.assertEqual(file.data, content)
 


### PR DESCRIPTION
If they don't, on Python 3 we run afoul of the zope.publisher rule that says that unicode response bodies need to have a content-type. But since the put view never sets a content type (due to being a
redirect), we get a TypeError instead:

```
  File "/py35/zope/app/wsgi/testlayer.py", line 210, in http
    response = request.get_response(wsgi_app)
  File "/py35/webob/request.py", line 1316, in send
    application, catch_exc_info=False)
  File "/py35/webob/request.py", line 1283, in call_application
    output.extend(app_iter)
  File "/py35/zope/app/wsgi/testlayer.py", line 94, in __call__
    for entry in self.wsgi_stack(environ, application_start_response):
  File "/py35/zope/app/wsgi/testlayer.py", line 68, in __call__
    for entry in self.wsgi_stack(environ, start_response):
  File "/py35/zope/app/wsgi/__init__.py", line 65, in __call__
    request = publish(request, handle_errors=handle_errors)
  File "/py35/zope/publisher/publish.py", line 148, in publish
    response.setResult(result)
  File "/py35/zope/publisher/http.py", line 796, in setResult
    r, headers = self._implicitResult(r)
  File "/py35/zope/publisher/http.py", line 821, in _implicitResult
    if not unicode_mimetypes_re.match(ct):
TypeError: expected string or bytes-like object
```

Here, `ct` is the content-type header, and its None. Returning bytes bypasses the issue (the previous line is `if isinstance(body, unicode):`).

This was discovered testing Python 3 with zope.app.file.