### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ CHANGES
 6.0 (unreleased)
 ----------------
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Add support for Python 3.12, 3.13.
 
 - Drop support for Python 3.7, 3.8.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-5.1 (unreleased)
+6.0 (unreleased)
 ----------------
 
 - Add support for Python 3.12, 3.13.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -60,9 +59,6 @@ setup(name='zope.app.http',
       ],
       url='https://github.com/zopefoundation/zope.app.http',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope', 'zope.app'],
       python_requires='>=3.9',
       extras_require=dict(
           test=[
@@ -74,7 +70,7 @@ setup(name='zope.app.http',
               'zope.principalregistry',
               'zope.securitypolicy >= 4.0.0a1',
               'zope.site >= 4.0.0a1',
-              'zope.testrunner',
+              'zope.testrunner >= 6.4',
           ]),
       install_requires=[
           'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read(*rnames):
 
 
 setup(name='zope.app.http',
-      version='5.1.dev0',
+      version='6.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.dev',
       description='HTTP Behavior for the Zope Publisher',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/zope/app/__init__.py
+++ b/src/zope/app/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
